### PR TITLE
Add Partner management resource

### DIFF
--- a/app/Filament/Resources/PartnerResource.php
+++ b/app/Filament/Resources/PartnerResource.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\PartnerResource\Pages;
+use App\Models\Partner;
+use Filament\Forms;
+use Filament\Forms\Components\{Section, Grid, TextInput, Textarea, FileUpload, Toggle};
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Tables\Columns\{TextColumn, IconColumn, ImageColumn};
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+
+class PartnerResource extends Resource
+{
+    protected static ?string $model = Partner::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-handshake';
+    protected static ?string $navigationGroup = 'Content Management';
+    protected static ?string $navigationLabel = 'Mitra';
+    protected static ?string $modelLabel = 'Mitra';
+    protected static ?string $pluralModelLabel = 'Mitra';
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Section::make('Informasi Mitra')
+                ->schema([
+                    Grid::make(2)->schema([
+                        TextInput::make('name')
+                            ->label('Nama Mitra')
+                            ->required()
+                            ->autofocus(),
+
+                        TextInput::make('slug')
+                            ->label('Slug')
+                            ->disabledOn('edit')
+                            ->readOnly(),
+                    ]),
+
+                    Textarea::make('description')
+                        ->label('Deskripsi')
+                        ->rows(3),
+
+                    TextInput::make('website_url')
+                        ->label('Website')
+                        ->url()
+                        ->suffixIcon('heroicon-o-arrow-top-right-on-square'),
+
+                    FileUpload::make('logo_path')
+                        ->label('Logo')
+                        ->image()
+                        ->directory('partners')
+                        ->disk('public'),
+
+                    Toggle::make('is_visible')
+                        ->label('Tampilkan')
+                        ->default(true),
+                ])->columns(1),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                ImageColumn::make('logo_path')
+                    ->label('Logo')
+                    ->disk('public')
+                    ->square(),
+
+                TextColumn::make('name')
+                    ->label('Nama')
+                    ->searchable()
+                    ->sortable(),
+
+                TextColumn::make('website_url')
+                    ->label('Website')
+                    ->url()
+                    ->limit(30),
+
+                IconColumn::make('is_visible')
+                    ->label('Tampil')
+                    ->boolean(),
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListPartners::route('/'),
+            'create' => Pages\CreatePartner::route('/create'),
+            'edit' => Pages\EditPartner::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/PartnerResource/Pages/CreatePartner.php
+++ b/app/Filament/Resources/PartnerResource/Pages/CreatePartner.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\PartnerResource\Pages;
+
+use App\Filament\Resources\PartnerResource;
+use Filament\Actions;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreatePartner extends CreateRecord
+{
+    protected static string $resource = PartnerResource::class;
+    protected static bool $canCreateAnother = false;
+
+    //customize redirect after create
+    public function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('index');
+    }
+}

--- a/app/Filament/Resources/PartnerResource/Pages/EditPartner.php
+++ b/app/Filament/Resources/PartnerResource/Pages/EditPartner.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Filament\Resources\PartnerResource\Pages;
+
+use App\Filament\Resources\PartnerResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditPartner extends EditRecord
+{
+    protected static string $resource = PartnerResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+        ];
+    }
+
+    //customize redirect after create
+    public function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('index');
+    }
+}

--- a/app/Filament/Resources/PartnerResource/Pages/ListPartners.php
+++ b/app/Filament/Resources/PartnerResource/Pages/ListPartners.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\PartnerResource\Pages;
+
+use App\Filament\Resources\PartnerResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListPartners extends ListRecords
+{
+    protected static string $resource = PartnerResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/database/factories/PartnerFactory.php
+++ b/database/factories/PartnerFactory.php
@@ -17,7 +17,11 @@ class PartnerFactory extends Factory
     public function definition(): array
     {
         return [
-            //
+            'name' => $this->faker->company(),
+            'description' => $this->faker->sentence(),
+            'website_url' => $this->faker->url(),
+            'logo_path' => null,
+            'is_visible' => true,
         ];
     }
 }

--- a/database/migrations/2025_08_03_090936_create_partners_table.php
+++ b/database/migrations/2025_08_03_090936_create_partners_table.php
@@ -13,6 +13,12 @@ return new class extends Migration
     {
         Schema::create('partners', function (Blueprint $table) {
             $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->text('description')->nullable();
+            $table->string('website_url')->nullable();
+            $table->string('logo_path')->nullable();
+            $table->boolean('is_visible')->default(true);
             $table->timestamps();
         });
     }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -26,7 +26,8 @@ class DatabaseSeeder extends Seeder
             [
                 PostSeeder::class,
                 ContactSeeder::class,
-                LearningPlatformSeeder::class
+                LearningPlatformSeeder::class,
+                PartnerSeeder::class,
             ]
         );
     }

--- a/database/seeders/PartnerSeeder.php
+++ b/database/seeders/PartnerSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Models\Partner;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -12,6 +13,12 @@ class PartnerSeeder extends Seeder
      */
     public function run(): void
     {
-        //
+        Partner::create([
+            'name' => 'PKBM Nurul Huda Jember',
+            'description' => 'Mitra pendidikan yang bekerja sama dengan platform.',
+            'website_url' => null,
+            'logo_path' => null,
+            'is_visible' => true,
+        ]);
     }
 }


### PR DESCRIPTION
## Summary
- define partners table with relevant fields
- seed example partner and expose factory
- add Filament Partner resource under Content Management navigation

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6896b42afb388329a4d3b2a847efef74