### PR TITLE
Add program participants pivot and management

### DIFF
--- a/app/Filament/Resources/ProgramResource.php
+++ b/app/Filament/Resources/ProgramResource.php
@@ -28,6 +28,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 use Filament\Tables\Actions\{Action, ActionGroup, ViewAction, EditAction, ReplicateAction};
+use App\Filament\Resources\ProgramResource\RelationManagers\ParticipantsRelationManager;
 
 class ProgramResource extends Resource
 {
@@ -424,7 +425,9 @@ class ProgramResource extends Resource
 
     public static function getRelations(): array
     {
-        return [];
+        return [
+            ParticipantsRelationManager::class,
+        ];
     }
 
     public static function getPages(): array

--- a/app/Filament/Resources/ProgramResource/Pages/ViewProgram.php
+++ b/app/Filament/Resources/ProgramResource/Pages/ViewProgram.php
@@ -9,6 +9,7 @@ use Filament\Infolists\Components\Section;
 use Filament\Infolists\Components\Grid;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Components\IconEntry;
+use Filament\Infolists\Components\RepeatableEntry;
 
 class ViewProgram extends ViewRecord
 {
@@ -123,6 +124,27 @@ class ViewProgram extends ViewRecord
                     ->columns([
                         'default' => 1,
                         'md' => 2,
+                    ])
+                    ->collapsed(true),
+
+                Section::make('Peserta')
+                    ->schema([
+                        RepeatableEntry::make('participants')
+                            ->schema([
+                                TextEntry::make('name')
+                                    ->label('Nama')
+                                    ->weight('semibold'),
+                                TextEntry::make('pivot.status')
+                                    ->label('Status')
+                                    ->badge()
+                                    ->color(fn($state) => match ($state) {
+                                        'completed' => 'success',
+                                        'in_progress' => 'warning',
+                                        default => 'gray',
+                                    }),
+                            ])
+                            ->columns(2)
+                            ->columnSpanFull(),
                     ])
                     ->collapsed(true),
             ])

--- a/app/Filament/Resources/ProgramResource/RelationManagers/ParticipantsRelationManager.php
+++ b/app/Filament/Resources/ProgramResource/RelationManagers/ParticipantsRelationManager.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Filament\Resources\ProgramResource\RelationManagers;
+
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Actions\AttachAction;
+use Filament\Tables\Actions\DetachAction;
+use Filament\Tables\Actions\DetachBulkAction;
+use Filament\Tables\Actions\EditAction;
+
+class ParticipantsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'participants';
+
+    public function form(Form $form): Form
+    {
+        return $form->schema([
+            Forms\Components\Select::make('status')
+                ->label('Status')
+                ->required(),
+        ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')->label('Nama')->searchable(),
+                TextColumn::make('pivot.status')->label('Status')->badge(),
+                TextColumn::make('pivot.created_at')
+                    ->label('Gabung')
+                    ->dateTime()->since(),
+            ])
+            ->headerActions([
+                AttachAction::make()->preloadRecordSelect()->form([
+                    Forms\Components\Select::make('status')
+                        ->label('Status')
+                        ->required(),
+                ]),
+            ])
+            ->actions([
+                EditAction::make()->form([
+                    Forms\Components\Select::make('status')
+                        ->label('Status')
+                        ->required(),
+                ]),
+                DetachAction::make(),
+            ])
+            ->bulkActions([
+                DetachBulkAction::make(),
+            ]);
+    }
+}

--- a/app/Models/Program.php
+++ b/app/Models/Program.php
@@ -36,6 +36,11 @@ class Program extends Model
         return $this->hasMany(Unit::class);
     }
 
+    public function participants()
+    {
+        return $this->belongsToMany(User::class)->withPivot('status')->withTimestamps();
+    }
+
     protected static function booted(): void
     {
         static::saving(function ($model) {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -70,4 +70,9 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, MustVerif
     {
         return true;
     }
+
+    public function programs()
+    {
+        return $this->belongsToMany(Program::class)->withPivot('status')->withTimestamps();
+    }
 }

--- a/database/migrations/2025_08_09_031530_create_program_user_table.php
+++ b/database/migrations/2025_08_09_031530_create_program_user_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('program_user', function (Blueprint $table) {
+            $table->foreignId('program_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('status')->nullable();
+            $table->timestamps();
+
+            $table->primary(['program_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('program_user');
+    }
+};


### PR DESCRIPTION
## Summary
- add `program_user` pivot table with status and timestamps
- connect programs and users via belongsToMany relationships
- manage participants from program page and display their status

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6896bcc9491c832981bc429e642c3889