### PR TITLE
feat(programs): manage units via relation manager

### DIFF
--- a/app/Filament/Resources/ProgramResource.php
+++ b/app/Filament/Resources/ProgramResource.php
@@ -424,7 +424,9 @@ class ProgramResource extends Resource
 
     public static function getRelations(): array
     {
-        return [];
+        return [
+            ProgramResource\RelationManagers\UnitsRelationManager::class,
+        ];
     }
 
     public static function getPages(): array

--- a/app/Filament/Resources/ProgramResource/RelationManagers/UnitsRelationManager.php
+++ b/app/Filament/Resources/ProgramResource/RelationManagers/UnitsRelationManager.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Filament\Resources\ProgramResource\RelationManagers;
+
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Forms\Components\Grid;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\Toggle;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Columns\ToggleColumn;
+use Illuminate\Validation\Rules\Unique;
+use Illuminate\Support\Str;
+
+class UnitsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'units';
+
+    protected static ?string $recordTitleAttribute = 'title';
+
+    public function form(Form $form): Form
+    {
+        return $form->schema([
+            Grid::make(2)->schema([
+                TextInput::make('title')
+                    ->label('Judul')
+                    ->required()
+                    ->reactive()
+                    ->afterStateUpdated(fn($state, callable $set) => $set('slug', Str::slug($state)))
+                    ->maxLength(255),
+                TextInput::make('slug')
+                    ->label('Slug')
+                    ->readOnly()
+                    ->required()
+                    ->maxLength(255)
+                    ->unique(ignoreRecord: true, modifyRuleUsing: function (Unique $rule) {
+                        return $rule->where('program_id', $this->ownerRecord->getKey());
+                    }),
+            ]),
+            Textarea::make('summary')
+                ->label('Ringkasan')
+                ->rows(3)
+                ->columnSpanFull(),
+            Grid::make(2)->schema([
+                TextInput::make('order')
+                    ->label('Urutan')
+                    ->numeric()
+                    ->required()
+                    ->unique(ignoreRecord: true, modifyRuleUsing: function (Unique $rule) {
+                        return $rule->where('program_id', $this->ownerRecord->getKey());
+                    }),
+                Toggle::make('is_visible')
+                    ->label('Tampilkan')
+                    ->default(true),
+            ]),
+        ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->reorderable('order')
+            ->columns([
+                TextColumn::make('title')
+                    ->label('Judul')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('order')
+                    ->label('Urutan')
+                    ->sortable(),
+                ToggleColumn::make('is_visible')
+                    ->label('Tampil'),
+            ])
+            ->headerActions([
+                Tables\Actions\CreateAction::make(),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\DeleteBulkAction::make(),
+            ]);
+    }
+}

--- a/database/migrations/2025_08_04_000000_update_units_unique_constraints.php
+++ b/database/migrations/2025_08_04_000000_update_units_unique_constraints.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('units', function (Blueprint $table) {
+            $table->dropUnique('units_slug_unique');
+            $table->unique(['program_id', 'slug']);
+            $table->unique(['program_id', 'order']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('units', function (Blueprint $table) {
+            $table->dropUnique('units_program_id_slug_unique');
+            $table->dropUnique('units_program_id_order_unique');
+            $table->unique('slug');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add Units relation manager to Program resource
- enforce unique slug and order per program
- allow ordering and visibility updates directly from program

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6896bccba9688329b8b2810fa3ace71d