### PR TITLE
Expose public program API via Filament API service

### DIFF
--- a/app/Filament/Resources/ProgramResource/Api/Handlers/EnrolmentHandler.php
+++ b/app/Filament/Resources/ProgramResource/Api/Handlers/EnrolmentHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Filament\Resources\ProgramResource\Api\Handlers;
+
+use App\Filament\Resources\ProgramResource;
+use Illuminate\Http\Request;
+use Rupadana\ApiService\Http\Handlers;
+
+class EnrolmentHandler extends Handlers
+{
+    public static ?string $uri = '/{id}/enrolments';
+    public static string $method = 'post';
+    public static ?string $resource = ProgramResource::class;
+    public static bool $public = false;
+
+    public static function getRouteMiddleware(): array
+    {
+        return ['auth:sanctum'];
+    }
+
+    public function handler(Request $request)
+    {
+        return response()->json([
+            'message' => 'Enrolment endpoint'
+        ]);
+    }
+}

--- a/app/Filament/Resources/ProgramResource/Api/Handlers/PublicDetailHandler.php
+++ b/app/Filament/Resources/ProgramResource/Api/Handlers/PublicDetailHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Filament\Resources\ProgramResource\Api\Handlers;
+
+use App\Filament\Resources\ProgramResource;
+use Illuminate\Http\Request;
+use Rupadana\ApiService\Http\Handlers;
+
+class PublicDetailHandler extends Handlers
+{
+    public static ?string $uri = '/{id}';
+    public static ?string $resource = ProgramResource::class;
+    public static bool $public = true;
+
+    /**
+     * Show a published program
+     *
+     * @param Request $request
+     * @return mixed
+     */
+    public function handler(Request $request)
+    {
+        $id = $request->route('id');
+
+        $record = static::getEloquentQuery()
+            ->where('is_published', true)
+            ->where(static::getKeyName(), $id)
+            ->first();
+
+        if (! $record) {
+            return static::sendNotFoundResponse();
+        }
+
+        $transformer = static::getApiTransformer();
+
+        return new $transformer($record);
+    }
+}

--- a/app/Filament/Resources/ProgramResource/Api/Handlers/PublicPaginationHandler.php
+++ b/app/Filament/Resources/ProgramResource/Api/Handlers/PublicPaginationHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Filament\Resources\ProgramResource\Api\Handlers;
+
+use App\Filament\Resources\ProgramResource;
+use Illuminate\Http\Request;
+use Rupadana\ApiService\Http\Handlers;
+use Spatie\QueryBuilder\QueryBuilder;
+
+class PublicPaginationHandler extends Handlers
+{
+    public static ?string $uri = '/';
+    public static ?string $resource = ProgramResource::class;
+    public static bool $public = true;
+
+    /**
+     * List published programs
+     *
+     * @param Request $request
+     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     */
+    public function handler()
+    {
+        $query = static::getEloquentQuery()->where('is_published', true);
+
+        $query = QueryBuilder::for($query)
+            ->allowedFields($this->getAllowedFields() ?? [])
+            ->allowedSorts($this->getAllowedSorts() ?? [])
+            ->allowedFilters($this->getAllowedFilters() ?? [])
+            ->allowedIncludes($this->getAllowedIncludes() ?? [])
+            ->paginate(request()->query('per_page'))
+            ->appends(request()->query());
+
+        $transformer = static::getApiTransformer();
+
+        return $transformer::collection($query);
+    }
+}

--- a/app/Filament/Resources/ProgramResource/Api/ProgramApiService.php
+++ b/app/Filament/Resources/ProgramResource/Api/ProgramApiService.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Filament\Resources\ProgramResource\Api;
+
+use App\Filament\Resources\ProgramResource;
+use Rupadana\ApiService\ApiService;
+
+class ProgramApiService extends ApiService
+{
+    protected static ?string $resource = ProgramResource::class;
+    protected static ?string $groupRouteName = 'programs';
+
+    public static function handlers(): array
+    {
+        return [
+            Handlers\PublicPaginationHandler::class,
+            Handlers\PublicDetailHandler::class,
+            Handlers\EnrolmentHandler::class,
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Http\Controllers\Api\AuthController;
+use App\Filament\Resources\ProgramResource\Api\ProgramApiService;
+use Filament\Facades\Filament;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -8,5 +10,7 @@ Route::get('/user', function (Request $request) {
     return $request->user();
 })->middleware('auth:sanctum');
 
+
+ProgramApiService::registerRoutes(Filament::getPanel('admin'));
 
 // Route::post('/login', [AuthController::class, 'login']);


### PR DESCRIPTION
## Summary
- add API service and handlers for ProgramResource
- expose only published programs and require Sanctum auth for enrolment route
- register Program API routes in `routes/api.php`

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6896bccc3f5c83298f11bdc94d0ea2a1