### PR TITLE
Fix ProgramResourceTable record URL call

### DIFF
--- a/app/Filament/Resources/ProgramResource/ProgramResourceTable.php
+++ b/app/Filament/Resources/ProgramResource/ProgramResourceTable.php
@@ -28,7 +28,7 @@ class ProgramResourceTable
         return $table
             ->heading('Daftar Program')
             ->description('Kelola program pembelajaran internal maupun eksternal.')
-            ->recordUrl(fn (Model $record) => static::getUrl('view', ['record' => $record]))
+            ->recordUrl(fn (Model $record) => \App\Filament\Resources\ProgramResource::getUrl('view', ['record' => $record]))
             ->columns([
                 TextColumn::make('title')
                     ->label('Judul')


### PR DESCRIPTION
## Summary
- reference `ProgramResource::getUrl` when building table record links

## Testing
- `./vendor/bin/pest`


------
https://chatgpt.com/codex/tasks/task_e_6897160195588329b92e49f51c98cfda