### PR TITLE
Add redirecting login route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,10 @@
 
 use Illuminate\Support\Facades\Route;
 
+Route::get('/login', function () {
+    return redirect()->route('filament.admin.auth.login');
+})->name('login');
+
 // Route::get('/', function () {
 //     return view('welcome');
 // });


### PR DESCRIPTION
## Summary
- add dedicated /login route that redirects to Filament's admin login

## Testing
- `php artisan test` *(fails: Route [filament.admin.auth.login] not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689735ed7cb083298aad5fc172878959