### PR TITLE
feat: enhance learning area resource

### DIFF
--- a/app/Filament/Resources/LearningAreaResource.php
+++ b/app/Filament/Resources/LearningAreaResource.php
@@ -2,13 +2,14 @@
 
 namespace App\Filament\Resources;
 
-use App\Filament\Resources\LearningAreaResource\Pages;
 use App\Filament\Resources\LearningAreaResource\LearningAreaResourceForm;
 use App\Filament\Resources\LearningAreaResource\LearningAreaResourceTable;
+use App\Filament\Resources\LearningAreaResource\Pages;
+use App\Filament\Resources\LearningAreaResource\RelationManagers\ProgramsRelationManager;
 use App\Filament\Resources\LearningAreaResource\Widgets\LearningAreaStats;
 use App\Models\LearningArea;
-use Filament\Resources\Resource;
 use Filament\Forms\Form;
+use Filament\Resources\Resource;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -17,10 +18,14 @@ class LearningAreaResource extends Resource
 {
     protected static ?string $model = LearningArea::class;
 
-    protected static ?string $navigationIcon  = 'heroicon-o-book-open';
+    protected static ?string $navigationIcon = 'heroicon-o-book-open';
+
     protected static ?string $navigationGroup = 'Content Management';
+
     protected static ?string $navigationLabel = 'Bidang Pembelajaran';
+
     protected static ?string $pluralModelLabel = 'Bidang Pembelajaran';
+
     protected static ?string $modelLabel = 'Bidang Pembelajaran';
 
     // Letakkan di urutan yang kamu mau (mis. ke-2 atau ke-3)
@@ -30,6 +35,7 @@ class LearningAreaResource extends Resource
     public static function getNavigationBadge(): ?string
     {
         $count = static::getModel()::query()->where('is_active', false)->count();
+
         return $count ? (string) $count : null;
     }
 
@@ -47,7 +53,7 @@ class LearningAreaResource extends Resource
     public static function getGlobalSearchResultDetails(Model $record): array
     {
         return [
-            'Slug'   => $record->slug,
+            'Slug' => $record->slug,
             'Status' => $record->is_active ? 'Aktif' : 'Nonaktif',
         ];
     }
@@ -85,18 +91,17 @@ class LearningAreaResource extends Resource
     public static function getRelations(): array
     {
         return [
-            // Contoh kalau nanti ada relasi Program:
-            // RelationManagers\ProgramsRelationManager::class,
+            ProgramsRelationManager::class,
         ];
     }
 
     public static function getPages(): array
     {
         return [
-            'index'  => Pages\ListLearningAreas::route('/'),
+            'index' => Pages\ListLearningAreas::route('/'),
             'create' => Pages\CreateLearningArea::route('/create'),
-            'view'   => Pages\ViewLearningArea::route('/{record}'),
-            'edit'   => Pages\EditLearningArea::route('/{record}/edit'),
+            'view' => Pages\ViewLearningArea::route('/{record}'),
+            'edit' => Pages\EditLearningArea::route('/{record}/edit'),
         ];
     }
 }

--- a/app/Filament/Resources/LearningAreaResource/LearningAreaResourceForm.php
+++ b/app/Filament/Resources/LearningAreaResource/LearningAreaResourceForm.php
@@ -2,8 +2,13 @@
 
 namespace App\Filament\Resources\LearningAreaResource;
 
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
 use Filament\Forms\Form;
-use Filament\Forms\Components\{Section, TextInput, Textarea, Toggle};
+use Filament\Forms\Set;
+use Illuminate\Support\Str;
 
 class LearningAreaResourceForm
 {
@@ -16,7 +21,9 @@ class LearningAreaResourceForm
                     TextInput::make('name')
                         ->label('Nama')
                         ->required()
-                        ->maxLength(100),
+                        ->maxLength(100)
+                        ->live(onBlur: true)
+                        ->afterStateUpdated(fn (Set $set, ?string $state) => $set('slug', Str::slug($state))),
 
                     TextInput::make('slug')
                         ->helperText('URL unik bidang, seperti "pemrograman-web"')
@@ -43,4 +50,3 @@ class LearningAreaResourceForm
         ]);
     }
 }
-

--- a/app/Filament/Resources/LearningAreaResource/LearningAreaResourceTable.php
+++ b/app/Filament/Resources/LearningAreaResource/LearningAreaResourceTable.php
@@ -2,30 +2,38 @@
 
 namespace App\Filament\Resources\LearningAreaResource;
 
-use Filament\Tables\Table;
 use Filament\Tables;
-use Filament\Tables\Columns\{TextColumn, IconColumn, ToggleColumn};
+use Filament\Tables\Actions\ActionGroup;
+use Filament\Tables\Actions\ViewAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Columns\ToggleColumn;
+use Filament\Tables\Table;
+use Pxlrbt\FilamentExcel\Actions\Tables\ExportAction;
 
 class LearningAreaResourceTable
 {
     public static function make(Table $table): Table
     {
         return $table
+            ->defaultPaginationPageOption(10)
             ->columns([
                 TextColumn::make('name')
                     ->label('Nama')
                     ->searchable()
                     ->sortable()
-                    ->description(fn($record) => $record->slug)
+                    ->description(fn ($record) => $record->slug)
                     ->weight('medium'),
 
-                IconColumn::make('is_active')
+                TextColumn::make('programs_count')
+                    ->label('Program')
+                    ->counts('programs')
+                    ->badge()
+                    ->sortable(),
+
+                ToggleColumn::make('is_active')
                     ->label('Aktif')
-                    ->boolean()
-                    ->trueIcon('heroicon-m-check-circle')
-                    ->falseIcon('heroicon-m-x-circle')
-                    ->trueColor('success')
-                    ->falseColor('gray'),
+                    ->onColor('success')
+                    ->offColor('gray'),
 
                 TextColumn::make('created_at')
                     ->label('Dibuat')
@@ -36,9 +44,15 @@ class LearningAreaResourceTable
                 Tables\Filters\TernaryFilter::make('is_active')
                     ->label('Status Aktif'),
             ])
+            ->headerActions([
+                ExportAction::make(),
+            ])
             ->actions([
-                Tables\Actions\EditAction::make(),
-                Tables\Actions\DeleteAction::make(),
+                ActionGroup::make([
+                    ViewAction::make(),
+                    Tables\Actions\EditAction::make(),
+                    Tables\Actions\DeleteAction::make(),
+                ]),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
@@ -47,4 +61,3 @@ class LearningAreaResourceTable
             ]);
     }
 }
-

--- a/app/Filament/Resources/LearningAreaResource/RelationManagers/ProgramsRelationManager.php
+++ b/app/Filament/Resources/LearningAreaResource/RelationManagers/ProgramsRelationManager.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Filament\Resources\LearningAreaResource\RelationManagers;
+
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Forms\Form;
+use Filament\Forms\Set;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Actions\CreateAction;
+use Filament\Tables\Actions\DeleteAction;
+use Filament\Tables\Actions\EditAction;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Support\Str;
+use Pxlrbt\FilamentExcel\Actions\Tables\ExportAction;
+
+class ProgramsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'programs';
+
+    protected static ?string $recordTitleAttribute = 'title';
+
+    public function form(Form $form): Form
+    {
+        return $form->schema([
+            TextInput::make('title')
+                ->label('Judul')
+                ->required()
+                ->live(onBlur: true)
+                ->afterStateUpdated(fn (Set $set, ?string $state) => $set('slug', Str::slug($state))),
+
+            TextInput::make('slug')
+                ->disabled()
+                ->dehydrated()
+                ->required()
+                ->unique(ignoreRecord: true),
+
+            Select::make('level')
+                ->label('Tingkat')
+                ->options([
+                    'pemula' => 'Pemula',
+                    'menengah' => 'Menengah',
+                    'lanjutan' => 'Lanjutan',
+                ])
+                ->required()
+                ->native(false),
+
+            Toggle::make('is_published')
+                ->label('Publikasi')
+                ->default(true),
+        ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('title')
+                    ->label('Judul')
+                    ->description(fn ($record) => $record->slug)
+                    ->searchable()
+                    ->sortable(),
+
+                TextColumn::make('level')
+                    ->label('Tingkat')
+                    ->badge(),
+
+                IconColumn::make('is_published')
+                    ->label('Publik')
+                    ->boolean(),
+
+                TextColumn::make('created_at')
+                    ->label('Dibuat')
+                    ->since()
+                    ->sortable(),
+            ])
+            ->headerActions([
+                CreateAction::make(),
+                ExportAction::make(),
+            ])
+            ->actions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add live slug generation and status toggle
- show program counts, export, and grouped actions
- manage programs directly from learning area

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68974bbf8ca48329bdcfac7edf3619d3