### PR TITLE
Add certificate model and enhance program participants management

### DIFF
--- a/app/Filament/Resources/ProgramResource/RelationManagers/ParticipantsRelationManager.php
+++ b/app/Filament/Resources/ProgramResource/RelationManagers/ParticipantsRelationManager.php
@@ -31,17 +31,33 @@ class ParticipantsRelationManager extends RelationManager
         return $table
             ->columns([
                 TextColumn::make('name')->label('Nama')->searchable(),
-                TextColumn::make('pivot.status')->label('Status')->badge(),
+                TextColumn::make('email')->label('Email')->searchable(),
+                TextColumn::make('pivot.status')
+                    ->label('Status')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'completed' => 'success',
+                        'in_progress' => 'warning',
+                        default => 'gray',
+                    }),
                 TextColumn::make('pivot.created_at')
                     ->label('Gabung')
-                    ->dateTime()->since(),
+                    ->dateTime()
+                    ->since(),
             ])
             ->headerActions([
-                AttachAction::make()->preloadRecordSelect()->form([
-                    Forms\Components\Select::make('status')
-                        ->label('Status')
-                        ->required(),
-                ]),
+                AttachAction::make()
+                    ->recordSelect(function (Forms\Components\Select $select) {
+                        return $select
+                            ->label('User')
+                            ->searchable()
+                            ->preload();
+                    })
+                    ->form([
+                        Forms\Components\Select::make('status')
+                            ->label('Status')
+                            ->required(),
+                    ]),
             ])
             ->actions([
                 EditAction::make()->form([

--- a/app/Models/Certificate.php
+++ b/app/Models/Certificate.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Certificate extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'program_id',
+        'user_id',
+        'path',
+        'issued_at',
+    ];
+
+    protected $casts = [
+        'issued_at' => 'datetime',
+    ];
+
+    public function program()
+    {
+        return $this->belongsTo(Program::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/Program.php
+++ b/app/Models/Program.php
@@ -41,6 +41,11 @@ class Program extends Model
         return $this->belongsToMany(User::class)->withPivot('status')->withTimestamps();
     }
 
+    public function certificates()
+    {
+        return $this->hasMany(Certificate::class);
+    }
+
     protected static function booted(): void
     {
         static::saving(function ($model) {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -75,4 +75,9 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, MustVerif
     {
         return $this->belongsToMany(Program::class)->withPivot('status')->withTimestamps();
     }
+
+    public function certificates()
+    {
+        return $this->hasMany(Certificate::class);
+    }
 }

--- a/database/migrations/2025_08_09_214800_create_certificates_table.php
+++ b/database/migrations/2025_08_09_214800_create_certificates_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('certificates', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('program_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('path')->nullable();
+            $table->timestamp('issued_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['program_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('certificates');
+    }
+};


### PR DESCRIPTION
## Summary
- add certificates table and model linked to programs and users
- expose certificate relations on Program and User models
- improve program participants management with user selection and richer table

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_6897c16caa9883298dd61004deddc973