### PR TITLE
feat: add Partner Filament resource

### DIFF
--- a/app/Filament/Resources/PartnerResource.php
+++ b/app/Filament/Resources/PartnerResource.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\PartnerResource\Pages;
+use App\Models\Partner;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Forms\Components\{Section, TextInput, Textarea, Toggle};
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Tables\Columns\{TextColumn, IconColumn};
+use Filament\Resources\Resource;
+use Illuminate\Support\Str;
+
+class PartnerResource extends Resource
+{
+    protected static ?string $model = Partner::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-handshake';
+    protected static ?string $navigationGroup = 'Content Management';
+    protected static ?string $navigationLabel = 'Partners';
+    protected static ?string $pluralModelLabel = 'Partners';
+    protected static ?string $modelLabel = 'Partner';
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Section::make('Informasi Partner')
+                ->description('Kelola nama, slug, dan deskripsi partner.')
+                ->schema([
+                    TextInput::make('name')
+                        ->label('Nama')
+                        ->required()
+                        ->maxLength(100)
+                        ->reactive()
+                        ->afterStateUpdated(fn($state, callable $set) => $set('slug', Str::slug((string) $state))),
+
+                    TextInput::make('slug')
+                        ->label('Slug')
+                        ->readOnly()
+                        ->maxLength(100),
+
+                    Textarea::make('description')
+                        ->label('Deskripsi')
+                        ->rows(3)
+                        ->columnSpanFull(),
+
+                    TextInput::make('website_url')
+                        ->label('Website')
+                        ->url()
+                        ->maxLength(255),
+
+                    TextInput::make('logo_path')
+                        ->label('Logo Path')
+                        ->maxLength(255),
+                ])->columns(2),
+
+            Section::make('Pengaturan')
+                ->collapsible()
+                ->schema([
+                    Toggle::make('is_visible')
+                        ->label('Tampilkan ke publik')
+                        ->default(true),
+                ]),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')
+                    ->label('Nama')
+                    ->searchable()
+                    ->sortable(),
+
+                TextColumn::make('website_url')
+                    ->label('Website')
+                    ->url(fn($record) => $record->website_url)
+                    ->openUrlInNewTab()
+                    ->toggleable(),
+
+                IconColumn::make('is_visible')
+                    ->label('Tampil')
+                    ->boolean()
+                    ->trueIcon('heroicon-m-check-circle')
+                    ->falseIcon('heroicon-m-x-circle')
+                    ->trueColor('success')
+                    ->falseColor('gray'),
+
+                TextColumn::make('created_at')
+                    ->label('Dibuat')
+                    ->since()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                Tables\Filters\TernaryFilter::make('is_visible')
+                    ->label('Status Tampil'),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListPartners::route('/'),
+            'create' => Pages\CreatePartner::route('/create'),
+            'edit' => Pages\EditPartner::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/PartnerResource/Pages/CreatePartner.php
+++ b/app/Filament/Resources/PartnerResource/Pages/CreatePartner.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Filament\Resources\PartnerResource\Pages;
+
+use App\Filament\Resources\PartnerResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreatePartner extends CreateRecord
+{
+    protected static string $resource = PartnerResource::class;
+
+    protected static bool $canCreateAnother = false;
+
+    public function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('index');
+    }
+}

--- a/app/Filament/Resources/PartnerResource/Pages/EditPartner.php
+++ b/app/Filament/Resources/PartnerResource/Pages/EditPartner.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Filament\Resources\PartnerResource\Pages;
+
+use App\Filament\Resources\PartnerResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditPartner extends EditRecord
+{
+    protected static string $resource = PartnerResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+
+    public function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('index');
+    }
+}

--- a/app/Filament/Resources/PartnerResource/Pages/ListPartners.php
+++ b/app/Filament/Resources/PartnerResource/Pages/ListPartners.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\PartnerResource\Pages;
+
+use App\Filament\Resources\PartnerResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListPartners extends ListRecords
+{
+    protected static string $resource = PartnerResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add Partner resource with form, table, and visibility toggle
- add List, Create, and Edit pages for managing partners

## Testing
- `composer dump-autoload` (fails: Class Illuminate\\Foundation\\ComposerScripts is not autoloadable)
- `php artisan test` (fails: Class "Illuminate\\Foundation\\Application" not found)


------
https://chatgpt.com/codex/tasks/task_e_689b7ada7f7c8329870b13be3ab0c1f6