### PR TITLE
Add partner schema and seed initial partners

### DIFF
--- a/database/factories/PartnerFactory.php
+++ b/database/factories/PartnerFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Partner>
@@ -16,8 +17,15 @@ class PartnerFactory extends Factory
      */
     public function definition(): array
     {
+        $name = $this->faker->unique()->company;
+
         return [
-            //
+            'name' => $name,
+            'slug' => Str::slug($name),
+            'description' => $this->faker->sentence(),
+            'website_url' => $this->faker->url(),
+            'logo_path' => null,
+            'is_visible' => true,
         ];
     }
 }

--- a/database/migrations/2025_08_03_090936_create_partners_table.php
+++ b/database/migrations/2025_08_03_090936_create_partners_table.php
@@ -13,6 +13,12 @@ return new class extends Migration
     {
         Schema::create('partners', function (Blueprint $table) {
             $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->text('description')->nullable();
+            $table->string('website_url')->nullable();
+            $table->string('logo_path')->nullable();
+            $table->boolean('is_visible')->default(true);
             $table->timestamps();
         });
     }

--- a/database/seeders/PartnerSeeder.php
+++ b/database/seeders/PartnerSeeder.php
@@ -2,8 +2,9 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use App\Models\Partner;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
 
 class PartnerSeeder extends Seeder
 {
@@ -12,6 +13,19 @@ class PartnerSeeder extends Seeder
      */
     public function run(): void
     {
-        //
+        $partnerNames = ['ASF', 'ASDFG', 'PKBM'];
+
+        foreach ($partnerNames as $name) {
+            Partner::updateOrCreate(
+                ['slug' => Str::slug($name)],
+                [
+                    'name' => $name,
+                    'description' => null,
+                    'website_url' => null,
+                    'logo_path' => null,
+                    'is_visible' => true,
+                ]
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- expand partner migration with name, slug, details, and visibility
- add factory and seeder to populate example partners including PKBM

## Testing
- `php artisan test` *(fails: expected status 200 but received 302)*

------
https://chatgpt.com/codex/tasks/task_e_689e9e587bc0832997a40070ded26da7