### PR TITLE
Add end-to-end Pest tests for core features

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,7 +22,9 @@
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
-        <env name="DB_DATABASE" value="testing"/>
+        <env name="APP_KEY" value="base64:FXlieNi8i59Zglzw+/8ryzbzNqp2Z7XIvKFtQU171ms="/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/tests/Feature/ApplicationFlowTest.php
+++ b/tests/Feature/ApplicationFlowTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use App\Models\User;
+use App\Models\LearningArea;
+use App\Models\Program;
+use Database\Seeders\DatabaseSeeder;
+use Database\Seeders\ShieldSeeder;
+use App\Filament\Resources\ProgramResource;
+use App\Filament\Resources\ProgramResource\Pages\CreateProgram;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Role;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('redirects guests to login when accessing program index', function () {
+    $this->get(ProgramResource::getUrl('index'))
+        ->assertRedirect('/login');
+});
+
+it('allows authenticated users to access program index', function () {
+    $this->seed(ShieldSeeder::class);
+    $role = Role::firstWhere('name', 'super_admin');
+    $user = User::factory()->create(['email_verified_at' => now()]);
+    $user->assignRole($role);
+    $this->actingAs($user);
+
+    Livewire::test(\App\Filament\Resources\ProgramResource\Pages\ListPrograms::class)
+        ->assertStatus(200);
+});
+
+it('ensures program belongs to learning area', function () {
+    $learningArea = LearningArea::factory()->create(['name' => 'Science']);
+
+    $program = Program::create([
+        'learning_area_id' => $learningArea->id,
+        'title' => 'Sample Program',
+        'description' => 'Sample description',
+        'level' => 'pemula',
+        'source' => 'external',
+        'platform' => 'Example',
+        'external_url' => 'https://example.com',
+        'is_certified' => true,
+        'is_published' => true,
+    ]);
+
+    expect($program->learningArea->is($learningArea))->toBeTrue();
+    expect($learningArea->programs)->toHaveCount(1);
+});
+
+it('seeds database with admin user', function () {
+    $this->seed(DatabaseSeeder::class);
+
+    $this->assertDatabaseHas('users', [
+        'email' => 'admin@admin.com',
+    ]);
+});
+
+it('allows creating a program via filament form', function () {
+    $this->seed(ShieldSeeder::class);
+    $role = Role::firstWhere('name', 'super_admin');
+    $user = User::factory()->create(['email_verified_at' => now()]);
+    $user->assignRole($role);
+    $this->actingAs($user);
+    $learningArea = LearningArea::factory()->create(['name' => 'Science']);
+
+    Livewire::test(CreateProgram::class)
+        ->fillForm([
+            'learning_area_id' => $learningArea->id,
+            'level' => 'pemula',
+            'title' => 'Filament Test Program',
+            'description' => 'Desc desc desc desc desc',
+            'source' => 'internal',
+            'is_certified' => true,
+            'is_published' => true,
+        ])
+        ->call('create')
+        ->assertHasNoErrors();
+
+    $this->assertDatabaseHas('programs', [
+        'title' => 'Filament Test Program',
+    ]);
+});
+

--- a/tests/Feature/ProgramResourceTest.php
+++ b/tests/Feature/ProgramResourceTest.php
@@ -1,0 +1,106 @@
+<?php
+
+use App\Filament\Resources\ProgramResource;
+use App\Filament\Resources\ProgramResource\Pages\CreateProgram;
+use App\Filament\Resources\ProgramResource\Pages\EditProgram;
+use App\Filament\Resources\ProgramResource\Pages\ViewProgram;
+use App\Models\LearningArea;
+use App\Models\Program;
+use App\Models\User;
+use Database\Seeders\ShieldSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Role;
+
+uses(RefreshDatabase::class);
+
+function actingAsSuperAdmin(): User {
+    test()->seed(ShieldSeeder::class);
+    $role = Role::firstWhere('name', 'super_admin');
+    $user = User::factory()->create(['email_verified_at' => now()]);
+    $user->assignRole($role);
+    test()->actingAs($user);
+    return $user;
+}
+
+it('redirects guests from program create page', function () {
+    $this->get(ProgramResource::getUrl('create'))
+        ->assertRedirect('/login');
+});
+
+it('forbids non privileged users from program index', function () {
+    $this->seed(ShieldSeeder::class);
+    $user = User::factory()->create(['email_verified_at' => now()]);
+    $this->actingAs($user);
+
+    $this->get(ProgramResource::getUrl('index'))
+        ->assertForbidden();
+});
+
+it('allows viewing program details', function () {
+    actingAsSuperAdmin();
+    $learningArea = LearningArea::factory()->create(['name' => 'Science']);
+    $program = Program::create([
+        'learning_area_id' => $learningArea->id,
+        'title' => 'Sample Program',
+        'description' => 'Sample description for viewing test',
+        'level' => 'pemula',
+        'source' => 'internal',
+        'is_certified' => true,
+        'is_published' => true,
+    ]);
+
+    Livewire::test(ViewProgram::class, ['record' => $program->getKey()])
+        ->assertStatus(200)
+        ->assertSee('Sample Program');
+});
+
+it('updates a program via filament form', function () {
+    actingAsSuperAdmin();
+    $learningArea = LearningArea::factory()->create(['name' => 'Science']);
+    $program = Program::create([
+        'learning_area_id' => $learningArea->id,
+        'title' => 'Original Title',
+        'description' => 'Original description for update test',
+        'level' => 'pemula',
+        'source' => 'internal',
+        'is_certified' => true,
+        'is_published' => true,
+    ]);
+
+    Livewire::test(EditProgram::class, ['record' => $program->getKey()])
+        ->fillForm([
+            'learning_area_id' => $learningArea->id,
+            'title' => 'Updated Title',
+            'description' => 'Original description for update test',
+            'level' => 'pemula',
+            'source' => 'internal',
+            'is_certified' => true,
+            'is_published' => true,
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas('programs', [
+        'id' => $program->id,
+        'title' => 'Updated Title',
+    ]);
+});
+
+it('validates required fields when creating a program', function () {
+    actingAsSuperAdmin();
+    $learningArea = LearningArea::factory()->create(['name' => 'Science']);
+
+    Livewire::test(CreateProgram::class)
+        ->fillForm([
+            'learning_area_id' => $learningArea->id,
+            'level' => 'pemula',
+            'description' => 'Desc desc desc desc desc',
+            'source' => 'internal',
+            'is_certified' => true,
+            'is_published' => true,
+        ])
+        ->call('create')
+        ->assertHasFormErrors(['title' => 'required']);
+});
+


### PR DESCRIPTION
## Summary
- add comprehensive Program Resource test suite covering guest redirects, role restrictions, viewing, editing, and validation
- configure phpunit with fixed APP_KEY for encrypted services during tests

## Testing
- `php artisan test tests/Feature/ProgramResourceTest.php`
- `php artisan test tests/Feature/ApplicationFlowTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68a36606adac8329b73a8f1cba86886a