### PR TITLE
Add teacher management and association with programs

### DIFF
--- a/app/Filament/Resources/ProgramResource.php
+++ b/app/Filament/Resources/ProgramResource.php
@@ -64,6 +64,7 @@ class ProgramResource extends Resource implements HasShieldPermissions
     {
         return [
             \App\Filament\Resources\ProgramResource\RelationManagers\EnrollmentsRelationManager::class,
+            \App\Filament\Resources\ProgramResource\RelationManagers\TeachersRelationManager::class,
         ];
     }
 

--- a/app/Filament/Resources/ProgramResource/RelationManagers/TeachersRelationManager.php
+++ b/app/Filament/Resources/ProgramResource/RelationManagers/TeachersRelationManager.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Filament\Resources\ProgramResource\RelationManagers;
+
+use Filament\Forms;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class TeachersRelationManager extends RelationManager
+{
+    protected static string $relationship = 'teachers';
+
+    public function form(Forms\Form $form): Forms\Form
+    {
+        return $form->schema([
+            Forms\Components\TextInput::make('name')->label('Nama')->required()->maxLength(255),
+            Forms\Components\Textarea::make('bio')->label('Bio')->rows(5)->columnSpanFull(),
+        ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name')->label('Nama')->searchable()->sortable(),
+            ])
+            ->headerActions([
+                Tables\Actions\AttachAction::make(),
+                Tables\Actions\CreateAction::make(),
+            ])
+            ->actions([
+                Tables\Actions\DetachAction::make(),
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\DetachBulkAction::make(),
+            ]);
+    }
+}

--- a/app/Filament/Resources/ProgramResource/Schema.php
+++ b/app/Filament/Resources/ProgramResource/Schema.php
@@ -62,6 +62,14 @@ class Schema extends ProgramResource
                                             ->live(),
                                     ]),
 
+                                    Select::make('teachers')
+                                        ->label('Pengajar')
+                                        ->relationship('teachers', 'name')
+                                        ->multiple()
+                                        ->preload()
+                                        ->searchable()
+                                        ->native(false),
+
                                     Grid::make(2)->schema([
                                         TextInput::make('title')
                                             ->label('Judul Program')

--- a/app/Filament/Resources/TeacherResource.php
+++ b/app/Filament/Resources/TeacherResource.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\TeacherResource\Pages;
+use App\Models\Teacher;
+use Filament\Forms;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Forms\Form;
+use Filament\Tables\Table;
+
+class TeacherResource extends Resource
+{
+    protected static ?string $model = Teacher::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-academic-cap';
+
+    protected static ?string $navigationGroup = 'Content Management';
+
+    protected static ?string $modelLabel = 'Pengajar';
+    protected static ?string $pluralModelLabel = 'Pengajar';
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Forms\Components\TextInput::make('name')->label('Nama')->required()->maxLength(255),
+            Forms\Components\Textarea::make('bio')->label('Bio')->rows(5)->columnSpanFull(),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name')->label('Nama')->searchable()->sortable(),
+                Tables\Columns\TextColumn::make('bio')->label('Bio')->limit(50),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\DeleteBulkAction::make(),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListTeachers::route('/'),
+            'create' => Pages\CreateTeacher::route('/create'),
+            'edit' => Pages\EditTeacher::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/TeacherResource/Pages/CreateTeacher.php
+++ b/app/Filament/Resources/TeacherResource/Pages/CreateTeacher.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\TeacherResource\Pages;
+
+use App\Filament\Resources\TeacherResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateTeacher extends CreateRecord
+{
+    protected static string $resource = TeacherResource::class;
+}

--- a/app/Filament/Resources/TeacherResource/Pages/EditTeacher.php
+++ b/app/Filament/Resources/TeacherResource/Pages/EditTeacher.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\TeacherResource\Pages;
+
+use App\Filament\Resources\TeacherResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditTeacher extends EditRecord
+{
+    protected static string $resource = TeacherResource::class;
+}

--- a/app/Filament/Resources/TeacherResource/Pages/ListTeachers.php
+++ b/app/Filament/Resources/TeacherResource/Pages/ListTeachers.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\TeacherResource\Pages;
+
+use App\Filament\Resources\TeacherResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListTeachers extends ListRecords
+{
+    protected static string $resource = TeacherResource::class;
+}

--- a/app/Models/Program.php
+++ b/app/Models/Program.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
+use App\Models\Teacher;
 
 class Program extends Model
 {
@@ -53,6 +54,11 @@ class Program extends Model
         return $this->belongsToMany(\App\Models\User::class, 'enrollments')
             ->withPivot(['status', 'enrolled_at', 'completed_at', 'notes'])
             ->withTimestamps();
+    }
+
+    public function teachers()
+    {
+        return $this->belongsToMany(Teacher::class);
     }
 
     protected static function booted(): void

--- a/app/Models/Teacher.php
+++ b/app/Models/Teacher.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Str;
+
+class Teacher extends Model
+{
+    use HasFactory;
+
+    protected $guarded = ['id'];
+    protected $hidden = ['created_at', 'updated_at'];
+
+    protected static function booted(): void
+    {
+        static::saving(function ($model) {
+            if (empty($model->slug)) {
+                $model->slug = Str::slug($model->name);
+            }
+        });
+    }
+
+    public function programs(): BelongsToMany
+    {
+        return $this->belongsToMany(Program::class);
+    }
+}

--- a/database/migrations/2025_09_02_000000_create_teachers_table.php
+++ b/database/migrations/2025_09_02_000000_create_teachers_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('teachers', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->text('bio')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('teachers');
+    }
+};

--- a/database/migrations/2025_09_02_010000_create_program_teacher_table.php
+++ b/database/migrations/2025_09_02_010000_create_program_teacher_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('program_teacher', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('program_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('teacher_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('program_teacher');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -20,6 +20,7 @@ class DatabaseSeeder extends Seeder
                 ShieldSeeder::class,
                 UsersWithRolesSeeder::class,
                 EnrollmentSeeder::class,
+                TeacherSeeder::class,
             ]
         );
     }

--- a/database/seeders/TeacherSeeder.php
+++ b/database/seeders/TeacherSeeder.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Program;
+use App\Models\Teacher;
+use Illuminate\Database\Seeder;
+
+class TeacherSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $teachers = [
+            ['name' => 'Budi Santoso', 'bio' => 'Ahli pemrograman dasar.'],
+            ['name' => 'Siti Nurhaliza', 'bio' => 'Praktisi komunikasi efektif.'],
+            ['name' => 'Rudi Hartono', 'bio' => 'Desainer UI/UX berpengalaman.'],
+        ];
+
+        foreach ($teachers as $data) {
+            Teacher::firstOrCreate(['name' => $data['name']], $data);
+        }
+
+        $programs = Program::all();
+        $teacherIds = Teacher::pluck('id');
+
+        foreach ($programs as $program) {
+            $program->teachers()->syncWithoutDetaching([$teacherIds->random()]);
+        }
+    }
+}

--- a/database/seeders/UsersWithRolesSeeder.php
+++ b/database/seeders/UsersWithRolesSeeder.php
@@ -26,7 +26,7 @@ class UsersWithRolesSeeder extends Seeder
 
             $spec = [
                 ['name' => 'Super Admin', 'email' => 'super.admin@example.com', 'role' => $superRole],
-                ['name' => 'Admin',       'email' => 'admin@example.com',       'role' => 'Admin'],
+                ['name' => 'Admin',       'email' => 'admin@admin.com',       'role' => 'Admin'],
                 ['name' => 'Pengajar',    'email' => 'pengajar@example.com',    'role' => 'Pengajar'],
                 ['name' => 'Pelajar',     'email' => 'pelajar@example.com',     'role' => 'Pelajar'],
                 ['name' => 'Tanpa Role',  'email' => 'user@example.com',        'role' => null],


### PR DESCRIPTION
## Summary
- add Teacher model, migrations and seeder
- link programs to teachers and expose in Filament
- include admin user email fix for seeders

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68b7f9dd297083299f8893221aa71bcf